### PR TITLE
Fix __future__ import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,0 @@
-
-__pycache__/keras_wavg.cpython-37.pyc

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+
+__pycache__/keras_wavg.cpython-37.pyc

--- a/SmilesGEN_bilstm_lstm_multi_encoding.py
+++ b/SmilesGEN_bilstm_lstm_multi_encoding.py
@@ -24,7 +24,7 @@ When using this code, please cite:
 """
 
 # Keras inputs
-from __future__ import print_function
+import __future__ 
 from keras import backend as K
 from keras.models import Model
 from keras.layers import Input,CuDNNLSTM,CuDNNGRU,Dense, Activation, Dropout,concatenate,average

--- a/SmilesGEN_generator.py
+++ b/SmilesGEN_generator.py
@@ -25,7 +25,7 @@ Please cite the above publication when using any part of its published code.
 """
 
 # Keras inputs
-from __future__ import print_function
+import __future__
 from keras import backend as K
 from keras.models import Sequential
 from keras.layers import Dense, Activation, Dropout


### PR DESCRIPTION
Although `from __future__ import print_function`  is at the first line of code it gives the error that it is not.

Fixed by only using `import __future__`.